### PR TITLE
Prevent redirect out of release flow

### DIFF
--- a/pages/3-release-notes-confluence.html
+++ b/pages/3-release-notes-confluence.html
@@ -66,7 +66,7 @@
         <div ng-if="btnTxt === 'Next'">
             <img height="32px;" width="32px;" src="../icons/success.ico">
             <p>Paste this link in your Email message:</p>
-            <a ng-href="{{html_url}}">{{html_url}}</a>
+            <a ng-href="{{html_url}}" target="_blank">{{html_url}}</a>
             <br><br>
         </div>
         <div ng-if="btnTxt === 'Close'">

--- a/pages/4-release-notes-github.html
+++ b/pages/4-release-notes-github.html
@@ -23,7 +23,7 @@
         <div ng-if="btnTxt === 'Next'">
             <img height="32px;" width="32px;" src="../icons/success.ico">
             <p>You can find your GitHub release notes here:</p>
-            <a ng-href="{{html_url}}">{{html_url}}</a>
+            <a ng-href="{{html_url}}" target="_blank">{{html_url}}</a>
             <br><br>
         </div>
         <div ng-if="btnTxt === 'Close'">


### PR DESCRIPTION
If you click on external link during release flow it takes you out of
the flow and you can’t come back, so open external links on new page.